### PR TITLE
[chore] upgrade action core

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@actions/core": "^1.4.0",
+    "@actions/core": "^1.10.0",
     "@actions/github": "^5.0.0",
     "toml": "^3.0.0"
   }


### PR DESCRIPTION
Remove warning regarding set-output

See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/